### PR TITLE
Fixed incorrect name folder

### DIFF
--- a/Source/Shared/Shared.projitems
+++ b/Source/Shared/Shared.projitems
@@ -19,7 +19,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)JSON\ChatMessagesJSON.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)JSON\CommandDetailsJSON.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)JSON\FileTransferJSON.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)misc\CommonValues.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Misc\CommonValues.cs" />
     <Compile Include="..\Shared\JSON\KeepAliveJSON.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)JSON\MapFileJSON.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Misc\CommonEnumerators.cs" />


### PR DESCRIPTION
When i run "Simple Builder.py", I found a bug "/Source/Shared/misc/CommonValues.cs' could not be found" on Linux
And i fixed him